### PR TITLE
Add options to create retry and error queues

### DIFF
--- a/lib/ears/setup.rb
+++ b/lib/ears/setup.rb
@@ -26,7 +26,7 @@ module Ears
     # @option args [Boolean] :error_queue (false) Whether an error queue should be created. The name of the queue will be the given name suffixed with ".error".
     # @return [Bunny::Queue] The queue that was either newly created or was already there.
     def queue(name, opts = {})
-      bunny_opts = opts.except(*QUEUE_PARAMS)
+      bunny_opts = opts.reject { |k, _| QUEUE_PARAMS.include?(k) }
       retry_delay = opts.fetch(:retry_delay, 5000)
 
       create_retry_queue(name, retry_delay, bunny_opts) if opts[:retry_queue]

--- a/lib/ears/setup.rb
+++ b/lib/ears/setup.rb
@@ -22,7 +22,7 @@ module Ears
     # @param [String] name The name of the queue.
     # @param [Hash] opts The options for the queue. These are passed on to +Bunny::Exchange.new+.
     # @option args [Boolean] :retry_queue (false) Whether a retry queue should be created. The retry queue is configured as a dead-letter-exchange of the original queue automatically. The name of the queue will be the given name suffixed with ".retry".
-    # @option args [Integer] :retry_delay (5000) How long a retried message is delayed before being routed back to the original queue.
+    # @option args [Integer] :retry_delay (5000) How long (in ms) a retried message is delayed before being routed back to the original queue.
     # @option args [Boolean] :error_queue (false) Whether an error queue should be created. The name of the queue will be the given name suffixed with ".error".
     # @return [Bunny::Queue] The queue that was either newly created or was already there.
     def queue(name, opts = {})

--- a/spec/ears/setup_spec.rb
+++ b/spec/ears/setup_spec.rb
@@ -53,6 +53,84 @@ RSpec.describe Ears::Setup do
 
       expect(Ears::Setup.new.queue('name', { test: 1 })).to eq(queue)
     end
+
+    it 'does not pass on options that are processed by ears' do
+      expect(Bunny::Queue).to receive(:new)
+        .with(
+          channel,
+          'name',
+          {
+            test: 1,
+            arguments: {
+              'x-dead-letter-exchange' => '',
+              'x-dead-letter-routing-key' => 'name.retry',
+            },
+          },
+        )
+        .and_return(queue)
+
+      expect(
+        Ears::Setup.new.queue(
+          'name',
+          { retry_queue: true, retry_delay: 1000, error_queue: true, test: 1 },
+        ),
+      ).to eq(queue)
+    end
+
+    it 'creates a retry queue with a derived name when option is set' do
+      expect(Bunny::Queue).to receive(:new).with(
+        channel,
+        'name.retry',
+        {
+          arguments: {
+            'x-message-ttl' => 5000,
+            'x-dead-letter-exchange' => '',
+            'x-dead-letter-routing-key' => 'name',
+          },
+        },
+      )
+
+      expect(Ears::Setup.new.queue('name', retry_queue: true)).to eq(queue)
+    end
+
+    it 'adds the retry queue as a deadletter to the original queue' do
+      expect(Bunny::Queue).to receive(:new).with(
+        channel,
+        'name',
+        {
+          arguments: {
+            'x-dead-letter-exchange' => '',
+            'x-dead-letter-routing-key' => 'name.retry',
+          },
+        },
+      )
+
+      expect(Ears::Setup.new.queue('name', retry_queue: true)).to eq(queue)
+    end
+
+    it 'uses the given retry delay for the retry queue' do
+      expect(Bunny::Queue).to receive(:new).with(
+        channel,
+        'name.retry',
+        {
+          arguments: {
+            'x-message-ttl' => 1000,
+            'x-dead-letter-exchange' => '',
+            'x-dead-letter-routing-key' => 'name',
+          },
+        },
+      )
+
+      expect(
+        Ears::Setup.new.queue('name', retry_queue: true, retry_delay: 1000),
+      ).to eq(queue)
+    end
+
+    it 'creates an error queue with derived name if option is set' do
+      expect(Bunny::Queue).to receive(:new).with(channel, 'name.error', {})
+
+      expect(Ears::Setup.new.queue('name', error_queue: true)).to eq(queue)
+    end
   end
 
   describe '#consumer' do


### PR DESCRIPTION
Related to https://github.com/ivx/open-spaces/issues/3652.

This is how we could potentially enforce naming conventions for retry and error queues and also reduce some of the boilerplate required to set those up. However, I'm not entirely sure I like how this works. I think I'm fine with the `retry_queue` and `retry_delay` arguments. However, the purpose of `error_queue` is just to enforce naming conventions, it doesn't do anything beyond that. And you also have to publish to it semi-manually by using the `MaxRetries` middleware, which is kinda implicit. What are your thoughts?