### PR TITLE
Do not crash on missing message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2 (2022-02-24)
+
+- change retry middleware to gracefully handle messages that do not have a header in their metadata
+
 ## 0.7.1 (2021-12-21)
 
 - explicitly report Appsignal errors in middleware to make it more reliable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.7.1)
+    ears (0.7.2)
       bunny
       multi_json
 

--- a/lib/ears/middlewares/max_retries.rb
+++ b/lib/ears/middlewares/max_retries.rb
@@ -30,6 +30,8 @@ module Ears
       end
 
       def retries_exceeded?(metadata)
+        return false if metadata.headers.nil?
+
         rejected_deaths =
           metadata
             .headers

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/spec/ears/middlewares/max_retries_spec.rb
+++ b/spec/ears/middlewares/max_retries_spec.rb
@@ -87,4 +87,14 @@ RSpec.describe Ears::Middlewares::MaxRetries do
       ).to eq(:moep)
     end
   end
+
+  context 'when metadata has no headers' do
+    let(:metadata) { instance_double(Bunny::MessageProperties, headers: nil) }
+
+    it 'returns downstream result if no death headers are present' do
+      expect(
+        middleware.call(delivery_info, metadata, payload, Proc.new { :moep }),
+      ).to eq(:moep)
+    end
+  end
 end


### PR DESCRIPTION
I tried using the retry middleware in a service that consumed messages that did not have a header in the metadata. These messages crashed the service, so I'm providing a way to handle missing headers.