### PR TITLE
Default JSON error handler to reject message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2 (2022-11-25)
+
+- default JSON middleware error handler to reject
+
 ## 0.8.1 (2022-04-08)
 
 - do not rescue errors outside the scope of the error handler in JSON middleware

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.8.1)
+    ears (0.8.2)
       bunny
       multi_json
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ require 'ears/middlewares/json'
 
 class MyConsumer < Ears::Consumer
   # register the JSON middleware and don't symbolize keys (this can be omitted, the default is true)
+  # and reject the message on parsing error. This defaults to Proc.new { :reject }.
   use Ears::Middlewares::JSON,
-      on_error: Proc.new { :reject },
+      on_error: Proc.new { :i_dont_care },
       symbolize_keys: false
 
   def work(delivery_info, metadata, payload)

--- a/lib/ears/middlewares/json.rb
+++ b/lib/ears/middlewares/json.rb
@@ -6,11 +6,11 @@ module Ears
     # A middleware that automatically parses your JSON payload.
     class JSON < Middleware
       # @param [Hash] opts The options for the middleware.
-      # @option opts [Proc] :on_error A Proc to be called when an error occurs during processing
+      # @option opts [Proc] :on_error (Proc.new { :reject }) A Proc to be called when an error occurs during processing.
       # @option opts [Boolean] :symbolize_keys (true) Whether to symbolize the keys of your payload.
       def initialize(opts = {})
         super()
-        @on_error = opts.fetch(:on_error)
+        @on_error = opts.fetch(:on_error, Proc.new { :reject })
         @symbolize_keys = opts.fetch(:symbolize_keys, true)
       end
 

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/ears/middlewares/json_spec.rb
+++ b/spec/ears/middlewares/json_spec.rb
@@ -43,8 +43,24 @@ RSpec.describe Ears::Middlewares::JSON do
       end.to yield_control
     end
 
-    it 'raises when initialized without error handler' do
-      expect { Ears::Middlewares::JSON.new }.to raise_error(KeyError)
+    context 'when initialized without error handler' do
+      let(:options) { {} }
+      let(:payload) { 'This is not JSON' }
+
+      it 'does not raise' do
+        expect { middleware }.not_to raise_error
+      end
+
+      it 'rejects when encountering an error' do
+        expect(
+          middleware.call(
+            delivery_info,
+            metadata,
+            payload,
+            Proc.new { :success },
+          ),
+        ).to eq(:reject)
+      end
     end
 
     it 'does not catch an error down the line' do


### PR DESCRIPTION
I would prefer this as a default. All the code where codecov is enabled currently has to look like this:

```ruby
  use Ears::Middlewares::JSON,
      # :nocov:
      on_error: Proc.new { :reject }
      # :nocov:
```

this is ugly.

Any objections?