### PR TITLE
Add recovery_attempts option to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.0 (2023-05-30)
+
+- _Breaking change:_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+  It comes with a default of 10 attempts. 
+
 ## 0.10.1 (2023-05-22)
 
 - Reset channel on Ears.stop!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0 (2023-05-30)
 
-- \_Breaking change:\_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+- **[Breaking]**: Provide the Bunny connection option `recovery_attempts` in Ears configuration.
   It comes with a default of 10 attempts.
 
 ## 0.10.1 (2023-05-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.11.0 (2023-05-30)
 
-- _Breaking change:_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
-  It comes with a default of 10 attempts. 
+- \_Breaking change:\_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+  It comes with a default of 10 attempts.
 
 ## 0.10.1 (2023-05-22)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.10.1)
+    ears (0.11.0)
       bunny
       multi_json
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require 'ears'
 Ears.configure do |config|
   config.rabbitmq_url = 'amqp://user:password@myrmq:5672'
   config.connection_name = 'My Consumer'
-  config.recover_from_connection_close = false, # optional configuration, defaults to true if not set
+  config.recover_from_connection_close = false # optional configuration, defaults to true if not set
   config.recovery_attempts = 3 # optional configuration, defaults to 10, Bunny::Session would have been nil
 end
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Ears.configure do |config|
   config.rabbitmq_url = 'amqp://user:password@myrmq:5672'
   config.connection_name = 'My Consumer'
   config.recover_from_connection_close = false, # optional configuration, defaults to true if not set
+  config.recovery_attempts = 3 # optional configuration, defaults to 10, Bunny::Session would have been nil
 end
 ```
 

--- a/lib/ears.rb
+++ b/lib/ears.rb
@@ -87,6 +87,7 @@ module Ears
         connection_name: configuration.connection_name,
         recover_from_connection_close:
           configuration.recover_from_connection_close,
+        recovery_attempts: configuration.recovery_attempts,
       }.compact
     end
   end

--- a/lib/ears/configuration.rb
+++ b/lib/ears/configuration.rb
@@ -5,6 +5,7 @@ module Ears
     end
 
     DEFAULT_RABBITMQ_URL = 'amqp://guest:guest@localhost:5672'
+    DEFAULT_RECOVERY_ATTEMPTS = 10
 
     # @return [String] the connection string for RabbitMQ.
     attr_accessor :rabbitmq_url
@@ -15,8 +16,12 @@ module Ears
     # @return [Boolean] if the recover_from_connection_close value is set for the RabbitMQ connection.
     attr_accessor :recover_from_connection_close
 
+    # @return [Integer] max number of recovery attempts, nil means forever
+    attr_accessor :recovery_attempts
+
     def initialize
       @rabbitmq_url = DEFAULT_RABBITMQ_URL
+      @recovery_attempts = DEFAULT_RECOVERY_ATTEMPTS
     end
 
     def validate!

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/spec/ears/configuration_spec.rb
+++ b/spec/ears/configuration_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Ears::Configuration do
     expect(configuration.recover_from_connection_close).to be(false)
   end
 
+  it 'allows setting the recovery_attempts' do
+    configuration.recovery_attempts = 2
+
+    expect(configuration.recovery_attempts).to eq(2)
+  end
+
+  it 'has a default recovery_attempt' do
+    expect(configuration.recovery_attempts).to eq(10)
+  end
+
   describe '#validate!' do
     it 'returns nil on valid configuration' do
       configuration.connection_name = 'test'

--- a/spec/ears_spec.rb
+++ b/spec/ears_spec.rb
@@ -43,23 +43,20 @@ RSpec.describe Ears do
   describe '.connection' do
     let(:rabbitmq_url) { 'amqp://lol:lol@kek.com:15672' }
     let(:connection_name) { 'my connection' }
-    let(:recover_from_connection_close) { false }
 
-    before do
-      Ears.configure do |config|
-        config.rabbitmq_url = rabbitmq_url
-        config.connection_name = connection_name
-        config.recover_from_connection_close = recover_from_connection_close
+    context 'when only mandatory options are set' do
+      before do
+        Ears.configure do |config|
+          config.rabbitmq_url = rabbitmq_url
+          config.connection_name = connection_name
+        end
       end
-    end
 
-    context 'when recover_from_connection_close is set' do
-      let(:recover_from_connection_close) { nil }
-
-      it 'connects with config parameters when it is accessed' do
+      it 'connects with default config parameters when it is accessed' do
         expect(Bunny).to receive(:new).with(
           rabbitmq_url,
           connection_name: connection_name,
+          recovery_attempts: 10,
         )
         expect(bunny).to receive(:start)
 
@@ -67,15 +64,30 @@ RSpec.describe Ears do
       end
     end
 
-    it 'connects with config parameters when it is accessed' do
-      expect(Bunny).to receive(:new).with(
-        rabbitmq_url,
-        connection_name: connection_name,
-        recover_from_connection_close: recover_from_connection_close,
-      )
-      expect(bunny).to receive(:start)
+    context 'with more options' do
+      let(:recover_from_connection_close) { false }
+      let(:recovery_attempts) { 5 }
 
-      Ears.connection
+      before do
+        Ears.configure do |config|
+          config.rabbitmq_url = rabbitmq_url
+          config.connection_name = connection_name
+          config.recover_from_connection_close = recover_from_connection_close
+          config.recovery_attempts = recovery_attempts
+        end
+      end
+
+      it 'connects with config parameters when it is accessed' do
+        expect(Bunny).to receive(:new).with(
+          rabbitmq_url,
+          connection_name: connection_name,
+          recover_from_connection_close: recover_from_connection_close,
+          recovery_attempts: recovery_attempts,
+        )
+        expect(bunny).to receive(:start)
+
+        Ears.connection
+      end
     end
   end
 


### PR DESCRIPTION
Add `recovery_attempts` to the connection configuration with a default of 10 attempts.

In the past we observed some applications that did not re-connectionto RabbitMQ properly. 
By providing this option and giving it a reasonable default, we want to make sure that an application crashes
and is restarted by Kubernetes every time runs into such a stale state.

Relates to: ivx/injixo#27165