### PR TITLE
Use Bunny's recovery_attempts feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.0 (2023-05-30)
+
+- _Breaking change:_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+  It comes with a default of 10 attempts. 
+
 ## 0.10.1 (2023-05-22)
 
 - Reset channel on Ears.stop!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **[Breaking]**: Provide the Bunny connection option `recovery_attempts` in Ears configuration. It
   comes with a default of 10 attempts. When the number of recovery attempts are exhausted, Ears will
-  rise a `MaxRecoveryAttemptsExhaustedError`.
+  raise a `MaxRecoveryAttemptsExhaustedError`.
 
 ## 0.10.1 (2023-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0 (2023-05-30)
 
-- \_Breaking change:\_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+- **[Breaking]**: Provide the Bunny connection option `recovery_attempts` in Ears configuration.
   It comes with a default of 10 attempts.
 
 ## 0.10.1 (2023-05-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.11.0 (2023-05-30)
 
-- _Breaking change:_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
-  It comes with a default of 10 attempts. 
+- \_Breaking change:\_Provide the Bunny connection option `recovery_attempts` in Ears configuration.
+  It comes with a default of 10 attempts.
 
 ## 0.10.1 (2023-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.11.0 (2023-05-30)
 
-- **[Breaking]**: Provide the Bunny connection option `recovery_attempts` in Ears configuration.
-  It comes with a default of 10 attempts.
+- **[Breaking]**: Provide the Bunny connection option `recovery_attempts` in Ears configuration. It
+  comes with a default of 10 attempts. When the number of recovery attempts are exhausted, Ears will
+  rise a `MaxRecoveryAttemptsExhaustedError`.
 
 ## 0.10.1 (2023-05-22)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.10.1)
+    ears (0.11.0)
       bunny
       multi_json
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ears (0.11.0)
-      bunny
+      bunny (~> 2.22.0)
       multi_json
 
 GEM
@@ -10,7 +10,7 @@ GEM
   specs:
     amq-protocol (2.3.2)
     ast (2.4.2)
-    bunny (2.21.0)
+    bunny (2.22.0)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
     diff-lcs (1.5.0)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Ears.configure do |config|
   config.rabbitmq_url = 'amqp://user:password@myrmq:5672'
   config.connection_name = 'My Consumer'
   config.recover_from_connection_close = false, # optional configuration, defaults to true if not set
+  config.recovery_attempts = 3 # optional configuration, defaults to 10, Bunny::Session would have been nil
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ require 'ears'
 Ears.configure do |config|
   config.rabbitmq_url = 'amqp://user:password@myrmq:5672'
   config.connection_name = 'My Consumer'
-  config.recover_from_connection_close = false, # optional configuration, defaults to true if not set
+  config.recover_from_connection_close = false # optional configuration, defaults to true if not set
   config.recovery_attempts = 3 # optional configuration, defaults to 10, Bunny::Session would have been nil
 end
 ```

--- a/ears.gemspec
+++ b/ears.gemspec
@@ -38,6 +38,6 @@ You may want to have a look into the CHANGELOG!
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bunny'
+  spec.add_dependency 'bunny', '~> 2.22.0'
   spec.add_dependency 'multi_json'
 end

--- a/lib/ears.rb
+++ b/lib/ears.rb
@@ -87,6 +87,7 @@ module Ears
         connection_name: configuration.connection_name,
         recover_from_connection_close:
           configuration.recover_from_connection_close,
+        recovery_attempts: configuration.recovery_attempts,
       }.compact
     end
   end

--- a/lib/ears.rb
+++ b/lib/ears.rb
@@ -88,6 +88,7 @@ module Ears
         recover_from_connection_close:
           configuration.recover_from_connection_close,
         recovery_attempts: configuration.recovery_attempts,
+        recovery_attempts_exhausted: configuration.recovery_attempts_exhausted,
       }.compact
     end
   end

--- a/lib/ears/configuration.rb
+++ b/lib/ears/configuration.rb
@@ -30,7 +30,13 @@ module Ears
     def recovery_attempts_exhausted
       return nil unless recovery_attempts
 
-      Proc.new { raise MaxRecoveryAttemptsExhaustedError }
+      Proc.new do
+        # We need to have this since Bunny’s multi-threading is cumbersome here.
+        # Session reconnection seems not to be done in the main thread. If we want to
+        # achieve a restart of the app we need to modify the thread behaviour.
+        Thread.current.abort_on_exception = true
+        raise MaxRecoveryAttemptsExhaustedError
+      end
     end
 
     def validate!

--- a/lib/ears/configuration.rb
+++ b/lib/ears/configuration.rb
@@ -1,3 +1,5 @@
+require 'ears/errors'
+
 module Ears
   # The class representing the global {Ears} configuration.
   class Configuration
@@ -22,6 +24,13 @@ module Ears
     def initialize
       @rabbitmq_url = DEFAULT_RABBITMQ_URL
       @recovery_attempts = DEFAULT_RECOVERY_ATTEMPTS
+    end
+
+    # @return [Proc] that is passed to Bunny’s recovery_attempts_exhausted block. Nil if recovery_attempts is nil.
+    def recovery_attempts_exhausted
+      return nil unless recovery_attempts
+
+      Proc.new { raise MaxRecoveryAttemptsExhaustedError }
     end
 
     def validate!

--- a/lib/ears/configuration.rb
+++ b/lib/ears/configuration.rb
@@ -5,6 +5,7 @@ module Ears
     end
 
     DEFAULT_RABBITMQ_URL = 'amqp://guest:guest@localhost:5672'
+    DEFAULT_RECOVERY_ATTEMPTS = 10
 
     # @return [String] the connection string for RabbitMQ.
     attr_accessor :rabbitmq_url
@@ -15,8 +16,12 @@ module Ears
     # @return [Boolean] if the recover_from_connection_close value is set for the RabbitMQ connection.
     attr_accessor :recover_from_connection_close
 
+    # @return [Integer] max number of recovery attempts, nil means forever
+    attr_accessor :recovery_attempts
+
     def initialize
       @rabbitmq_url = DEFAULT_RABBITMQ_URL
+      @recovery_attempts = DEFAULT_RECOVERY_ATTEMPTS
     end
 
     def validate!

--- a/lib/ears/errors.rb
+++ b/lib/ears/errors.rb
@@ -1,0 +1,5 @@
+module Ears
+  # Error that is raised when the Bunny recovery attempts are exhausted.
+  class MaxRecoveryAttemptsExhaustedError < StandardError
+  end
+end

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/spec/ears/configuration_spec.rb
+++ b/spec/ears/configuration_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Ears::Configuration do
     expect(configuration.recover_from_connection_close).to be(false)
   end
 
+  it 'allows setting the recovery_attempts' do
+    configuration.recovery_attempts = 2
+
+    expect(configuration.recovery_attempts).to eq(2)
+  end
+
+  it 'has a default recovery_attempt' do
+    expect(configuration.recovery_attempts).to eq(10)
+  end
+
   describe '#validate!' do
     it 'returns nil on valid configuration' do
       configuration.connection_name = 'test'

--- a/spec/ears/configuration_spec.rb
+++ b/spec/ears/configuration_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe Ears::Configuration do
     expect(configuration.recovery_attempts).to eq(10)
   end
 
+  context 'when recovery attempts are set' do
+    before { configuration.recovery_attempts = 2 }
+
+    it 'sets recovery_attempts_exhausted to a raising proc' do
+      proc = configuration.recovery_attempts_exhausted
+
+      expect { proc.call }.to raise_error(
+        Ears::MaxRecoveryAttemptsExhaustedError,
+      )
+    end
+  end
+
+  context 'when recovery attempts are set to nil' do
+    before { configuration.recovery_attempts = nil }
+
+    it 'sets also recovery_attempts_exhausted to nil' do
+      expect(configuration.recovery_attempts).to be_nil
+    end
+  end
+
   describe '#validate!' do
     it 'returns nil on valid configuration' do
       configuration.connection_name = 'test'

--- a/spec/ears_spec.rb
+++ b/spec/ears_spec.rb
@@ -43,23 +43,20 @@ RSpec.describe Ears do
   describe '.connection' do
     let(:rabbitmq_url) { 'amqp://lol:lol@kek.com:15672' }
     let(:connection_name) { 'my connection' }
-    let(:recover_from_connection_close) { false }
 
-    before do
-      Ears.configure do |config|
-        config.rabbitmq_url = rabbitmq_url
-        config.connection_name = connection_name
-        config.recover_from_connection_close = recover_from_connection_close
+    context 'when only mandatory options are set' do
+      before do
+        Ears.configure do |config|
+          config.rabbitmq_url = rabbitmq_url
+          config.connection_name = connection_name
+        end
       end
-    end
 
-    context 'when recover_from_connection_close is set' do
-      let(:recover_from_connection_close) { nil }
-
-      it 'connects with config parameters when it is accessed' do
+      it 'connects with default config parameters when it is accessed' do
         expect(Bunny).to receive(:new).with(
           rabbitmq_url,
           connection_name: connection_name,
+          recovery_attempts: 10,
         )
         expect(bunny).to receive(:start)
 
@@ -67,15 +64,30 @@ RSpec.describe Ears do
       end
     end
 
-    it 'connects with config parameters when it is accessed' do
-      expect(Bunny).to receive(:new).with(
-        rabbitmq_url,
-        connection_name: connection_name,
-        recover_from_connection_close: recover_from_connection_close,
-      )
-      expect(bunny).to receive(:start)
+    context 'with more options' do
+      let(:recover_from_connection_close) { false }
+      let(:recovery_attempts) { 5 }
 
-      Ears.connection
+      before do
+        Ears.configure do |config|
+          config.rabbitmq_url = rabbitmq_url
+          config.connection_name = connection_name
+          config.recover_from_connection_close = recover_from_connection_close
+          config.recovery_attempts = recovery_attempts
+        end
+      end
+
+      it 'connects with config parameters when it is accessed' do
+        expect(Bunny).to receive(:new).with(
+          rabbitmq_url,
+          connection_name: connection_name,
+          recover_from_connection_close: recover_from_connection_close,
+          recovery_attempts: recovery_attempts,
+        )
+        expect(bunny).to receive(:start)
+
+        Ears.connection
+      end
     end
   end
 


### PR DESCRIPTION
A few weeks ago, we tried to overcome the Bunny reconnect issues described in https://github.com/ivx/injixo/issues/27165 by utilising Bunny's `reconnect_attempts`. Sadly, we identified a feature gap in Bunny that prevented the desired behaviour.

With the new version of Bunny, this feature gap is closed and we can start a second try.

This PR implements a `max recovery attempts` solution that raises an error if Bunny wasn't able to reconnect to RabbitMQ after the specified attempts.