### PR TITLE
Add Yard configuration

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,5 @@
+--readme README.md
+--title 'Ears Documentation'
+--charset utf-8
+--markup markdown
+'lib/**/*.rb' - 'README.md' 'LICENSE.txt' 'CHANGELOG.md'

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
+require 'rake/clean'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'yard'
 
-RSpec::Core::RakeTask.new(:spec)
+CLEAN << '.yardoc'
+CLOBBER << 'doc'
 
-YARD::Rake::YardocTask.new { |t| t.files = ['lib/**/*.rb'] }
+RSpec::Core::RakeTask.new(:spec)
+YARD::Rake::YardocTask.new { |t| t.stats_options = %w[--list-undoc] }
 
 task default: :spec


### PR DESCRIPTION
Using a proper YARD file allows us to publish the documentation at https://rubydoc.info.