### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.2 (2023-10-25)
+
+- Add documentation generation via yard
+
 ## 0.11.1 (2023-09-08)
 
 - Bugfix: trapped signals INT and TERM now calls correctly previous set signal handler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.11.1)
+    ears (0.11.2)
       bunny (~> 2.22.0)
       multi_json
 

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end


### PR DESCRIPTION
This releases https://github.com/ivx/ears/pull/32 so that it can show up in rubydocs.info