### PR TITLE
Adjust Appsignal monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.0 (2024-07-29)
+
+- **[Breaking]** Adjust Appsignal middleware to use `Appsignal.monitor`.  
+  To use the middleware the `appsignal` gem in version `>= 3.11.0` is required.  
+  The configuration of the middleware changed and now only requires one option `class_name` and an optional `namespace`.
+
 ## 0.13.0 (2023-11-07)
 
 - Allow adding multiple routing keys to the consumer configuration, configure method within consumer will only accept `routing_keys` array instead of `routing_key` string

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.13.0)
+    ears (0.14.0)
       bunny (~> 2.22.0)
       multi_json
 

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end

--- a/spec/ears/middlewares/appsignal_spec.rb
+++ b/spec/ears/middlewares/appsignal_spec.rb
@@ -7,28 +7,23 @@ RSpec.describe Ears::Middlewares::Appsignal do
   let(:payload) { 'payload' }
   let(:appsignal) { stub_const('Appsignal', Class.new) }
   let(:middleware) do
-    Ears::Middlewares::Appsignal.new(
-      transaction_name: 'perform_job.test',
-      class_name: 'MyConsumer',
-    )
+    Ears::Middlewares::Appsignal.new(class_name: 'MyConsumer')
   end
   let(:now) { Time.utc(2020) }
 
   before { allow(Time).to receive_message_chain(:now, :utc).and_return(now) }
 
   it 'returns the result of the downstream middleware' do
-    expect(appsignal).to receive(:monitor_transaction).and_yield
+    expect(appsignal).to receive(:monitor).and_yield
     expect(
       middleware.call(delivery_info, metadata, payload, Proc.new { :moep }),
     ).to eq(:moep)
   end
 
   it 'starts an Appsignal transaction and calls the downstream middleware' do
-    expect(appsignal).to receive(:monitor_transaction).with(
-      'perform_job.test',
-      class: 'MyConsumer',
-      method: 'work',
-      queue_start: now,
+    expect(appsignal).to receive(:monitor).with(
+      namespace: 'background',
+      action: 'MyConsumer#work',
     ).and_yield
     expect { |b|
       middleware.call(delivery_info, metadata, payload, Proc.new(&b))
@@ -37,7 +32,7 @@ RSpec.describe Ears::Middlewares::Appsignal do
 
   it 'calls set_error when an error is raised' do
     error = RuntimeError.new('moep')
-    expect(appsignal).to receive(:monitor_transaction).and_yield
+    expect(appsignal).to receive(:monitor).and_yield
     expect(appsignal).to receive(:set_error).with(error)
 
     expect do
@@ -48,5 +43,24 @@ RSpec.describe Ears::Middlewares::Appsignal do
         Proc.new { raise error },
       )
     end.to raise_error(error)
+  end
+
+  context 'with namespace' do
+    let(:middleware) do
+      Ears::Middlewares::Appsignal.new(
+        namespace: 'cronjob',
+        class_name: 'MyConsumer',
+      )
+    end
+
+    it 'starts an Appsignal transaction with the given namespace and calls the downstream middleware' do
+      expect(appsignal).to receive(:monitor).with(
+        namespace: 'cronjob',
+        action: 'MyConsumer#work',
+      ).and_yield
+      expect { |b|
+        middleware.call(delivery_info, metadata, payload, Proc.new(&b))
+      }.to yield_control
+    end
   end
 end


### PR DESCRIPTION
With `appsignal 3.11.0` `Appsignal.monitor_transaction` was deprecated in favor of `Appsignal.monitor`.

This PR adjusts the way how we call Appsignal in the middleware.