### PR TITLE
Add instrumentation in Appsignal middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.1 (2024-07-31)
+
+- Add instrumentation around block in Appsignal middleware
+
 ## 0.14.0 (2024-07-29)
 
 - **[Breaking]** Adjust Appsignal middleware to use `Appsignal.monitor`.  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.14.0)
+    ears (0.14.1)
       bunny (~> 2.22.0)
       multi_json
 

--- a/lib/ears/middlewares/appsignal.rb
+++ b/lib/ears/middlewares/appsignal.rb
@@ -32,8 +32,7 @@ module Ears
         ::Appsignal.monitor(
           namespace: namespace,
           action: "#{class_name}#work",
-          &block
-        )
+        ) { ::Appsignal.instrument('process_message.ears', &block) }
       end
     end
   end

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.14.0'
+  VERSION = '0.14.1'
 end


### PR DESCRIPTION
Wrap block in instrumentation `process_message.ears` to improve visibility within Appsignal.