### PR TITLE
Maintenance 2025 01 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           bundler-cache: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '23'
       - name: Run prettier
         run: npm ci && npm run lint
       - name: Run Rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - Guardfile
     - bin/*
     - tmp/**/*
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 Style:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.8
-nodejs 22.8.0
+ruby 3.4.1
+nodejs 23.6.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.4.1
+ruby 3.0.7
 nodejs 23.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## 0.15.0 (2025-01-14)
+
+- Drop support for ruby 2.7
+- Add support for ruby 3.4
+
 ## 0.14.1 (2024-07-31)
 
 - Add instrumentation around block in Appsignal middleware
 
 ## 0.14.0 (2024-07-29)
 
-- **[Breaking]** Adjust Appsignal middleware to use `Appsignal.monitor`.  
-  To use the middleware the `appsignal` gem in version `>= 3.11.0` is required.  
+- **[Breaking]** Adjust Appsignal middleware to use `Appsignal.monitor`.
+  To use the middleware the `appsignal` gem in version `>= 3.11.0` is required.
   The configuration of the middleware changed and now only requires one option `class_name` and an optional `namespace`.
 
 ## 0.13.0 (2023-11-07)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.22
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.14.1)
+    ears (0.15.0)
       bunny (~> 2.22.0)
       multi_json
 
@@ -19,11 +19,12 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
-    json (2.7.2)
+    json (2.9.1)
     language_server-protocol (3.17.0.3)
+    logger (1.6.5)
     multi_json (1.15.0)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     prettier (4.0.4)
@@ -34,40 +35,41 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    rbs (3.1.3)
+    rbs (3.6.1)
+      logger
     rbtree (0.4.6)
-    regexp_parser (2.9.2)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.1)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
-    rubocop (1.66.1)
+    rspec-support (3.13.2)
+    rubocop (1.70.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (3.0.5)
+    rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    set (1.0.4)
+    set (1.1.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -89,8 +91,10 @@ GEM
       syntax_tree (>= 2.0.1)
     temple (0.10.3)
     thor (1.3.2)
-    tilt (2.4.0)
-    unicode-display_width (2.6.0)
+    tilt (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     yard (0.9.37)
 
 PLATFORMS
@@ -115,4 +119,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.6.2
+   2.5.23

--- a/ears.gemspec
+++ b/ears.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A gem for building RabbitMQ consumers.'
   spec.homepage = 'https://github.com/ivx/ears'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.7')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.14.1'
+  VERSION = '0.15.0'
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@invisionag/prettier-config": "^2.1.3",
         "@prettier/plugin-ruby": "^4.0.4",
-        "prettier": "^3.3.3"
+        "prettier": "^3.4.2"
       }
     },
     "node_modules/@invisionag/prettier-config": {
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -62,9 +62,9 @@
       "requires": {}
     },
     "prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@invisionag/prettier-config": "^2.1.3",
     "@prettier/plugin-ruby": "^4.0.4",
-    "prettier": "^3.3.3"
+    "prettier": "^3.4.2"
   },
   "prettier": "@invisionag/prettier-config/ruby"
 }


### PR DESCRIPTION
TODO:
- [x] drop support for 2.7 in GH actions
- [x] recheck upgrade GH actions
- [x] version bump & CHANGELOG for 2.7 support drop