### PR TITLE
Recover StandardError immediately after connection recovery

### DIFF
--- a/spec/ears/publisher_retry_handler_spec.rb
+++ b/spec/ears/publisher_retry_handler_spec.rb
@@ -318,12 +318,12 @@ RSpec.describe Ears::PublisherRetryHandler do
 
       before { allow(mock_connection).to receive(:open?).and_return(true) }
 
-      it 'handles connection error but raises standard error immediately' do
-        expect { handler.run(&complex_block) }.to raise_error(standard_error)
+      it 'retries both connection and standard errors and eventually succeeds' do
+        result = handler.run(&complex_block)
 
-        expect(Ears::PublisherChannelPool).to have_received(:reset!)
-
-        expect(handler).not_to have_received(:sleep)
+        expect(result).to eq('finally success')
+        expect(Ears::PublisherChannelPool).to have_received(:reset!).once
+        expect(handler).to have_received(:sleep).once
       end
     end
   end


### PR DESCRIPTION
The previous implementation had a shortcoming of not allowing to recover from a StandardError occurring immediately after recovering from a ConnectionError. This change addresses this and also reduces complexity by not having to pass the called block around.