### PR TITLE
Provide test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.21.1 (2025-09-09)
+
+- Add testing abstractions: `Ears::Testing::TestHelper`, `Ears::Testing::MessageCapture`, and `Ears::Testing::PublisherMock`
+
 ## 0.21.0 (2025-09-08)
 
 - Introduce Ears::Publisher with thread-safe channel pooling

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.21.0)
+    ears (0.21.1)
       bunny (>= 2.22.0)
       connection_pool (~> 2.4)
       multi_json
@@ -113,7 +113,7 @@ CHECKSUMS
   connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  ears (0.21.0)
+  ears (0.21.1)
   json (2.13.2) sha256=02e1f118d434c6b230a64ffa5c8dee07e3ec96244335c392eaed39e1199dbb68
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/lib/ears/testing.rb
+++ b/lib/ears/testing.rb
@@ -1,0 +1,37 @@
+require 'ears'
+require 'ears/testing/test_helper'
+require 'ears/testing/message_capture'
+require 'ears/testing/publisher_mock'
+
+module Ears
+  module Testing
+    class << self
+      attr_accessor :message_capture
+
+      def configure
+        yield(configuration) if block_given?
+      end
+
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def reset!
+        @message_capture = nil
+        @configuration = nil
+      end
+    end
+
+    class Configuration
+      attr_accessor :max_captured_messages,
+                    :auto_cleanup,
+                    :strict_exchange_mocking
+
+      def initialize
+        @max_captured_messages = 1000
+        @auto_cleanup = true
+        @strict_exchange_mocking = true
+      end
+    end
+  end
+end

--- a/lib/ears/testing/message_capture.rb
+++ b/lib/ears/testing/message_capture.rb
@@ -1,0 +1,89 @@
+module Ears
+  module Testing
+    class MessageCapture
+      Message =
+        Struct.new(
+          :exchange_name,
+          :routing_key,
+          :data,
+          :options,
+          :timestamp,
+          :thread_id,
+          keyword_init: true,
+        )
+
+      def initialize
+        @messages = {}
+        @mutex = Mutex.new
+      end
+
+      def add_message(exchange_name, data, routing_key, options = {})
+        @mutex.synchronize do
+          @messages[exchange_name] ||= []
+
+          message =
+            Message.new(
+              exchange_name: exchange_name,
+              routing_key: routing_key,
+              data: data,
+              options: options,
+              timestamp: Time.now,
+              thread_id: Thread.current.object_id.to_s,
+            )
+
+          @messages[exchange_name] << message
+
+          shift_messages(exchange_name)
+
+          message
+        end
+      end
+
+      def messages_for(exchange_name)
+        @mutex.synchronize { (@messages[exchange_name] || []).dup }
+      end
+
+      def all_messages
+        @mutex.synchronize { @messages.values.flatten }
+      end
+
+      def clear
+        @mutex.synchronize { @messages.clear }
+      end
+
+      def count(exchange_name = nil)
+        @mutex.synchronize do
+          return (@messages[exchange_name] || []).size if exchange_name
+
+          @messages.values.sum(&:size)
+        end
+      end
+
+      def empty?
+        @mutex.synchronize do
+          @messages.empty? || @messages.values.all?(&:empty?)
+        end
+      end
+
+      def find_messages(exchange_name: nil, routing_key: nil, data: nil)
+        messages = exchange_name ? messages_for(exchange_name) : all_messages
+
+        messages.select do |msg|
+          next false if routing_key && msg.routing_key != routing_key
+          next false if data && msg.data != data
+
+          true
+        end
+      end
+
+      private
+
+      def shift_messages(exchange_name)
+        max_messages = Ears::Testing.configuration.max_captured_messages
+        if @messages[exchange_name].size > max_messages
+          @messages[exchange_name].shift
+        end
+      end
+    end
+  end
+end

--- a/lib/ears/testing/publisher_mock.rb
+++ b/lib/ears/testing/publisher_mock.rb
@@ -1,0 +1,102 @@
+require 'rspec/mocks'
+
+module Ears
+  module Testing
+    class UnmockedExchangeError < StandardError
+    end
+
+    class PublisherMock
+      include RSpec::Mocks::ExampleMethods
+
+      def initialize(exchange_names, message_capture)
+        @exchange_names = Array(exchange_names)
+        @message_capture = message_capture
+        @mock_exchanges = {}
+      end
+
+      def setup_mocks
+        setup_connection
+        setup_channel_pool
+      end
+
+      private
+
+      attr_reader :exchange_names, :message_capture, :mock_exchanges
+
+      def setup_connection
+        mock_connection = instance_double(Bunny::Session, open?: true)
+        Ears.instance_variable_set(:@connection, mock_connection)
+      end
+
+      def setup_channel_pool
+        mock_channel = create_mock_channel
+        allow(Ears::PublisherChannelPool).to receive(:with_channel).and_yield(
+          mock_channel,
+        )
+        mock_channel
+      end
+
+      def create_mock_channel
+        instance_double(Bunny::Channel).tap do |channel|
+          setup_exchange_declare(channel)
+          setup_register_exchange(channel)
+          setup_basic_publish(channel)
+        end
+      end
+
+      def setup_exchange_declare(channel)
+        allow(channel).to receive(:exchange_declare) do |name, type, options|
+          create_or_get_mock_exchange(name, type, options)
+        end
+      end
+
+      def setup_register_exchange(channel)
+        allow(channel).to receive(:register_exchange)
+      end
+
+      def setup_basic_publish(channel)
+        allow(channel).to receive(
+          :basic_publish,
+        ) do |data, exchange, routing_key, options|
+          if exchange_names.include?(exchange)
+            capture_message(exchange, data, routing_key, options)
+          elsif strict_mocking?
+            raise_unmocked_exchange_error(exchange)
+          end
+        end
+      end
+
+      def create_or_get_mock_exchange(name, type, _options)
+        mock_exchanges[name] ||= create_mock_exchange(name, type)
+      end
+
+      def create_mock_exchange(name, type)
+        exchange = instance_double(Bunny::Exchange, name: name, type: type)
+
+        setup_exchange_publish(exchange, name)
+
+        exchange
+      end
+
+      def setup_exchange_publish(exchange, name)
+        allow(exchange).to receive(:publish) do |data, routing_options|
+          routing_key = routing_options[:routing_key]
+          capture_message(name, data, routing_key, routing_options)
+        end
+      end
+
+      def capture_message(exchange_name, data, routing_key, options)
+        message_capture.add_message(exchange_name, data, routing_key, options)
+      end
+
+      def strict_mocking?
+        Ears::Testing.configuration.strict_exchange_mocking
+      end
+
+      def raise_unmocked_exchange_error(exchange)
+        raise UnmockedExchangeError,
+              "Exchange '#{exchange}' has not been mocked. Add mock_ears('#{exchange}') to your test setup."
+      end
+    end
+  end
+end

--- a/lib/ears/testing/test_helper.rb
+++ b/lib/ears/testing/test_helper.rb
@@ -1,0 +1,50 @@
+require 'rspec/mocks'
+
+module Ears
+  module Testing
+    module TestHelper
+      include RSpec::Mocks::ExampleMethods
+
+      def mock_ears(*exchange_names)
+        Ears::Testing.message_capture ||= MessageCapture.new
+
+        @original_connection = Ears.instance_variable_get(:@connection)
+
+        publisher_mock =
+          PublisherMock.new(exchange_names, Ears::Testing.message_capture)
+        publisher_mock.setup_mocks
+      end
+
+      def ears_reset!
+        Ears::Testing.message_capture = nil
+
+        if instance_variable_defined?(:@original_connection)
+          Ears.instance_variable_set(:@connection, @original_connection)
+          remove_instance_variable(:@original_connection)
+        end
+
+        if defined?(Ears::PublisherChannelPool)
+          Ears::PublisherChannelPool.reset!
+        end
+      end
+
+      def published_messages(exchange_name = nil)
+        return [] unless Ears::Testing.message_capture
+
+        if exchange_name
+          return Ears::Testing.message_capture.messages_for(exchange_name)
+        end
+
+        Ears::Testing.message_capture.all_messages
+      end
+
+      def last_published_message(exchange_name = nil)
+        published_messages(exchange_name).last
+      end
+
+      def clear_published_messages
+        Ears::Testing.message_capture&.clear
+      end
+    end
+  end
+end

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.21.0'
+  VERSION = '0.21.1'
 end

--- a/spec/ears/testing/integration_spec.rb
+++ b/spec/ears/testing/integration_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'ears/testing'
+require 'ears/publisher'
+
+RSpec.describe 'Ears Testing Integration' do # rubocop:disable RSpec/DescribeClass
+  include Ears::Testing::TestHelper
+
+  before { mock_ears('events', 'notifications') }
+
+  after { ears_reset! }
+
+  it 'captures messages published through Ears::Publisher' do
+    publisher = Ears::Publisher.new('events')
+
+    publisher.publish(
+      { id: 1, name: 'Test Event' },
+      routing_key: 'user.created',
+      headers: {
+        version: '1.0',
+      },
+    )
+
+    messages = published_messages('events')
+    expect(messages.size).to eq(1)
+
+    message = messages.first
+    expect(message.routing_key).to eq('user.created')
+    expect(message.data).to eq({ id: 1, name: 'Test Event' })
+    expect(message.options[:headers]).to include(version: '1.0')
+  end
+
+  it 'captures messages from multiple publishers' do
+    events_publisher = Ears::Publisher.new('events')
+    notifications_publisher = Ears::Publisher.new('notifications')
+
+    events_publisher.publish({ event: 'login' }, routing_key: 'user.login')
+    notifications_publisher.publish(
+      { notify: 'welcome' },
+      routing_key: 'email.send',
+    )
+    events_publisher.publish({ event: 'logout' }, routing_key: 'user.logout')
+
+    expect(published_messages('events').size).to eq(2)
+    expect(published_messages('notifications').size).to eq(1)
+    expect(published_messages.size).to eq(3)
+  end
+
+  it 'provides access to the last published message' do
+    publisher = Ears::Publisher.new('events')
+
+    publisher.publish({ id: 1 }, routing_key: 'first')
+    publisher.publish({ id: 2 }, routing_key: 'second')
+    publisher.publish({ id: 3 }, routing_key: 'third')
+
+    expect(last_published_message('events').data).to eq({ id: 3 })
+    expect(last_published_message.routing_key).to eq('third')
+  end
+
+  it 'allows clearing messages during test' do
+    publisher = Ears::Publisher.new('events')
+
+    publisher.publish({ id: 1 }, routing_key: 'test')
+    expect(published_messages).not_to be_empty
+
+    clear_published_messages
+    expect(published_messages).to be_empty
+
+    publisher.publish({ id: 2 }, routing_key: 'test')
+    expect(published_messages.size).to eq(1)
+  end
+
+  it 'raises error when publishing to unmocked exchange' do
+    expect {
+      Ears::Publisher.new('unmocked').publish(
+        { test: 'data' },
+        routing_key: 'test',
+      )
+    }.to raise_error(
+      Ears::Testing::UnmockedExchangeError,
+      /Exchange 'unmocked' has not been mocked/,
+    )
+  end
+end

--- a/spec/ears/testing/integration_spec.rb
+++ b/spec/ears/testing/integration_spec.rb
@@ -5,7 +5,10 @@ require 'ears/publisher'
 RSpec.describe 'Ears Testing Integration' do # rubocop:disable RSpec/DescribeClass
   include Ears::Testing::TestHelper
 
-  before { mock_ears('events', 'notifications') }
+  before do
+    Ears.configuration.publisher_max_retries = 0
+    mock_ears('events', 'notifications')
+  end
 
   after { ears_reset! }
 

--- a/spec/ears/testing/message_capture_spec.rb
+++ b/spec/ears/testing/message_capture_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+require 'ears/testing'
+require 'ears/testing/message_capture'
+
+RSpec.describe Ears::Testing::MessageCapture do
+  subject(:capture) { described_class.new }
+
+  before do
+    allow(Ears::Testing).to receive(:configuration).and_return(
+      instance_double(Ears::Testing::Configuration, max_captured_messages: 3),
+    )
+  end
+
+  describe '#add_message' do
+    it 'stores a message with all attributes' do
+      message =
+        capture.add_message(
+          'exchange1',
+          { id: 1 },
+          'routing.key',
+          { persistent: true },
+        )
+
+      expect(message).to have_attributes(
+        exchange_name: 'exchange1',
+        routing_key: 'routing.key',
+        data: {
+          id: 1,
+        },
+        options: {
+          persistent: true,
+        },
+        timestamp: be_within(1).of(Time.now),
+        thread_id: Thread.current.object_id.to_s,
+      )
+    end
+
+    it 'stores messages per exchange' do
+      capture.add_message('exchange1', 'data1', 'key1')
+      capture.add_message('exchange2', 'data2', 'key2')
+      capture.add_message('exchange1', 'data3', 'key3')
+
+      expect(capture.messages_for('exchange1')).to have_attributes(size: 2)
+      expect(capture.messages_for('exchange2')).to have_attributes(size: 1)
+    end
+
+    it 'respects max_captured_messages limit' do
+      4.times { |i| capture.add_message('exchange1', "data#{i}", 'key') }
+
+      messages = capture.messages_for('exchange1')
+      expect(messages.size).to eq(3)
+      expect(messages.first.data).to eq('data1')
+      expect(messages.last.data).to eq('data3')
+    end
+
+    it 'is thread-safe' do
+      threads = []
+      mutex = Mutex.new
+      results = []
+
+      10.times do |i|
+        threads << Thread.new do
+          message = capture.add_message('exchange1', "data#{i}", 'key')
+          mutex.synchronize { results << message }
+        end
+      end
+
+      threads.each(&:join)
+      expect(results.size).to eq(10)
+      expect(results.map(&:data).uniq.size).to eq(10)
+    end
+  end
+
+  describe '#messages_for' do
+    it 'returns messages for specific exchange' do
+      capture.add_message('exchange1', 'data1', 'key1')
+      capture.add_message('exchange2', 'data2', 'key2')
+
+      messages = capture.messages_for('exchange1')
+      expect(messages.size).to eq(1)
+      expect(messages.first.data).to eq('data1')
+    end
+
+    it 'returns empty array for unknown exchange' do
+      expect(capture.messages_for('unknown')).to eq([])
+    end
+
+    it 'returns a copy of messages' do
+      capture.add_message('exchange1', 'data1', 'key1')
+      messages = capture.messages_for('exchange1')
+      messages.clear
+
+      expect(capture.messages_for('exchange1').size).to eq(1)
+    end
+  end
+
+  describe '#all_messages' do
+    it 'returns messages from all exchanges' do
+      capture.add_message('exchange1', 'data1', 'key1')
+      capture.add_message('exchange2', 'data2', 'key2')
+      capture.add_message('exchange1', 'data3', 'key3')
+
+      expect(capture.all_messages.size).to eq(3)
+      expect(capture.all_messages.map(&:data)).to contain_exactly(
+        'data1',
+        'data2',
+        'data3',
+      )
+    end
+  end
+
+  describe '#clear' do
+    it 'removes all messages' do
+      capture.add_message('exchange1', 'data1', 'key1')
+      capture.add_message('exchange2', 'data2', 'key2')
+
+      capture.clear
+
+      expect(capture.all_messages).to be_empty
+      expect(capture.messages_for('exchange1')).to be_empty
+      expect(capture.messages_for('exchange2')).to be_empty
+    end
+  end
+
+  describe '#count' do
+    before do
+      capture.add_message('exchange1', 'data1', 'key1')
+      capture.add_message('exchange2', 'data2', 'key2')
+      capture.add_message('exchange1', 'data3', 'key3')
+    end
+
+    it 'returns count for specific exchange' do
+      expect(capture.count('exchange1')).to eq(2)
+      expect(capture.count('exchange2')).to eq(1)
+    end
+
+    it 'returns total count when no exchange specified' do
+      expect(capture.count).to eq(3)
+    end
+
+    it 'returns 0 for unknown exchange' do
+      expect(capture.count('unknown')).to eq(0)
+    end
+  end
+
+  describe '#empty?' do
+    it 'returns true when no messages' do
+      expect(capture).to be_empty
+    end
+
+    it 'returns false when messages exist' do
+      capture.add_message('exchange1', 'data', 'key')
+      expect(capture).not_to be_empty
+    end
+
+    it 'returns true after clearing' do
+      capture.add_message('exchange1', 'data', 'key')
+      capture.clear
+      expect(capture).to be_empty
+    end
+  end
+
+  describe '#find_messages' do
+    before do
+      capture.add_message('exchange1', { id: 1 }, 'user.created')
+      capture.add_message('exchange1', { id: 2 }, 'user.updated')
+      capture.add_message('exchange2', { id: 3 }, 'user.created')
+    end
+
+    it 'finds messages by exchange_name' do
+      messages = capture.find_messages(exchange_name: 'exchange1')
+      expect(messages.map { |m| m.data[:id] }).to contain_exactly(1, 2)
+    end
+
+    it 'finds messages by routing_key' do
+      messages = capture.find_messages(routing_key: 'user.created')
+      expect(messages.map { |m| m.data[:id] }).to contain_exactly(1, 3)
+    end
+
+    it 'finds messages by data' do
+      messages = capture.find_messages(data: { id: 2 })
+      expect(messages.size).to eq(1)
+      expect(messages.first.routing_key).to eq('user.updated')
+    end
+
+    it 'combines multiple criteria' do
+      messages =
+        capture.find_messages(
+          exchange_name: 'exchange1',
+          routing_key: 'user.created',
+        )
+      expect(messages.size).to eq(1)
+      expect(messages.first.data).to eq({ id: 1 })
+    end
+  end
+end

--- a/spec/ears/testing/publisher_mock_spec.rb
+++ b/spec/ears/testing/publisher_mock_spec.rb
@@ -1,0 +1,179 @@
+require 'spec_helper'
+require 'ears/testing'
+require 'ears/publisher_channel_pool'
+
+RSpec.describe Ears::Testing::PublisherMock do
+  subject(:publisher_mock) do
+    described_class.new(exchange_names, message_capture)
+  end
+
+  let(:message_capture) { Ears::Testing::MessageCapture.new }
+  let(:exchange_names) { ['test_exchange'] }
+
+  before do
+    allow(Ears::Testing).to receive(:configuration).and_return(
+      instance_double(
+        Ears::Testing::Configuration,
+        strict_exchange_mocking: true,
+        max_captured_messages: 100,
+      ),
+    )
+  end
+
+  describe '#setup_mocks' do
+    it 'returns a mock channel' do
+      channel = publisher_mock.setup_mocks
+      expect(channel).to respond_to(:basic_publish)
+      expect(channel).to respond_to(:exchange_declare)
+    end
+
+    it 'sets up a mock connection on Ears' do
+      publisher_mock.setup_mocks
+      connection = Ears.instance_variable_get(:@connection)
+      expect(connection).to respond_to(:open?)
+      expect(connection.open?).to be true
+    end
+
+    it 'mocks PublisherChannelPool.with_channel' do
+      expect(Ears::PublisherChannelPool).to receive(:with_channel)
+      publisher_mock.setup_mocks
+      Ears::PublisherChannelPool.with_channel { |_channel| 'block executed' }
+    end
+
+    context 'with multiple exchanges' do
+      let(:exchange_names) { %w[exchange1 exchange2 exchange3] }
+
+      it 'sets up mocks for all exchanges' do
+        channel = publisher_mock.setup_mocks
+
+        exchange_names.each do |exchange_name|
+          expect(channel).to receive(:basic_publish).with(
+            'test_data',
+            exchange_name,
+            'test.key',
+            hash_including(:persistent, :content_type),
+          )
+        end
+
+        exchange_names.each do |exchange_name|
+          channel.basic_publish(
+            'test_data',
+            exchange_name,
+            'test.key',
+            { persistent: true, content_type: 'application/json' },
+          )
+        end
+      end
+    end
+  end
+
+  describe 'message capturing' do
+    let(:channel) { publisher_mock.setup_mocks }
+
+    it 'captures published messages' do
+      channel.basic_publish(
+        '{"id": 1}',
+        'test_exchange',
+        'test.routing.key',
+        { persistent: true, content_type: 'application/json' },
+      )
+
+      messages = message_capture.messages_for('test_exchange')
+      expect(messages.size).to eq(1)
+      expect(messages.first).to have_attributes(
+        exchange_name: 'test_exchange',
+        routing_key: 'test.routing.key',
+        data: '{"id": 1}',
+        options:
+          hash_including(persistent: true, content_type: 'application/json'),
+      )
+    end
+
+    it 'captures multiple messages' do
+      3.times do |i|
+        channel.basic_publish(
+          "data_#{i}",
+          'test_exchange',
+          "key_#{i}",
+          { persistent: true, content_type: 'application/json' },
+        )
+      end
+
+      messages = message_capture.messages_for('test_exchange')
+      expect(messages.size).to eq(3)
+      expect(messages.map(&:data)).to eq(%w[data_0 data_1 data_2])
+    end
+  end
+
+  describe 'exchange declaration' do
+    let(:channel) { publisher_mock.setup_mocks }
+
+    it 'allows exchange declaration' do
+      expect {
+        channel.exchange_declare('test_exchange', :topic, durable: true)
+      }.not_to raise_error
+    end
+
+    it 'returns a mock exchange' do
+      exchange =
+        channel.exchange_declare('test_exchange', :topic, durable: true)
+      expect(exchange).to respond_to(:publish)
+      expect(exchange.name).to eq('test_exchange')
+      expect(exchange.type).to eq(:topic)
+    end
+
+    it 'allows publishing through declared exchange' do
+      exchange =
+        channel.exchange_declare('test_exchange', :topic, durable: true)
+
+      exchange.publish('test_data', routing_key: 'test.key')
+
+      messages = message_capture.messages_for('test_exchange')
+      expect(messages.size).to eq(1)
+      expect(messages.first.data).to eq('test_data')
+    end
+  end
+
+  describe 'strict exchange mocking' do
+    let(:channel) { publisher_mock.setup_mocks }
+
+    context 'when strict_exchange_mocking is true' do
+      it 'raises error for unmocked exchange' do
+        expect {
+          channel.basic_publish('data', 'unmocked_exchange', 'key', {})
+        }.to raise_error(
+          Ears::Testing::UnmockedExchangeError,
+          "Exchange 'unmocked_exchange' has not been mocked. Add mock_ears('unmocked_exchange') to your test setup.",
+        )
+      end
+    end
+
+    context 'when strict_exchange_mocking is false' do
+      before do
+        allow(Ears::Testing.configuration).to receive(
+          :strict_exchange_mocking,
+        ).and_return(false)
+      end
+
+      it 'does not raise error for unmocked exchange' do
+        expect {
+          channel.basic_publish('data', 'unmocked_exchange', 'key', {})
+        }.not_to raise_error
+      end
+
+      it 'does not capture messages for unmocked exchange' do
+        channel.basic_publish('data', 'unmocked_exchange', 'key', {})
+        expect(message_capture.messages_for('unmocked_exchange')).to be_empty
+      end
+    end
+  end
+
+  describe 'register_exchange support' do
+    let(:channel) { publisher_mock.setup_mocks }
+
+    it 'allows register_exchange calls' do
+      exchange = instance_double(Bunny::Exchange, name: 'test_exchange')
+      expect { channel.register_exchange(exchange) }.not_to raise_error
+    end
+  end
+end

--- a/spec/ears/testing/test_helper_spec.rb
+++ b/spec/ears/testing/test_helper_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'ears/testing'
+
+RSpec.describe Ears::Testing::TestHelper do
+  subject(:helper) { test_class.new }
+
+  let(:test_class) { Class.new { include Ears::Testing::TestHelper } }
+
+  before { Ears::Testing.reset! }
+
+  after { helper.ears_reset! if helper.respond_to?(:ears_reset!) }
+
+  describe '#mock_ears' do
+    it 'returns a mock channel' do
+      channel = helper.mock_ears('test_exchange')
+      expect(channel).to be_an_instance_of(
+        RSpec::Mocks::InstanceVerifyingDouble,
+      )
+    end
+
+    it 'sets up message capture' do
+      helper.mock_ears('test_exchange')
+      expect(Ears::Testing.message_capture).to be_an_instance_of(
+        Ears::Testing::MessageCapture,
+      )
+    end
+
+    it 'accepts multiple exchange names' do
+      channel = helper.mock_ears('exchange1', 'exchange2', 'exchange3')
+      expect(channel).not_to be_nil
+    end
+
+    it 'stores original connection for cleanup' do
+      original_connection = instance_double(Bunny::Session)
+      Ears.instance_variable_set(:@connection, original_connection)
+
+      helper.mock_ears('test_exchange')
+
+      expect(helper.instance_variable_get(:@original_connection)).to eq(
+        original_connection,
+      )
+    end
+  end
+
+  describe '#published_messages' do
+    before do
+      helper.mock_ears('exchange1', 'exchange2')
+      Ears::Testing.message_capture.add_message('exchange1', 'data1', 'key1')
+      Ears::Testing.message_capture.add_message('exchange2', 'data2', 'key2')
+      Ears::Testing.message_capture.add_message('exchange1', 'data3', 'key3')
+    end
+
+    it 'returns all messages when no exchange specified' do
+      messages = helper.published_messages
+      expect(messages.size).to eq(3)
+      expect(messages.map(&:data)).to contain_exactly('data1', 'data2', 'data3')
+    end
+
+    it 'returns messages for specific exchange' do
+      messages = helper.published_messages('exchange1')
+      expect(messages.size).to eq(2)
+      expect(messages.map(&:data)).to contain_exactly('data1', 'data3')
+    end
+
+    it 'returns empty array when no messages captured' do
+      helper.clear_published_messages
+      expect(helper.published_messages).to eq([])
+    end
+  end
+
+  describe '#last_published_message' do
+    before do
+      helper.mock_ears('exchange1')
+      Ears::Testing.message_capture.add_message('exchange1', 'first', 'key1')
+      Ears::Testing.message_capture.add_message('exchange1', 'last', 'key2')
+    end
+
+    it 'returns the last message for an exchange' do
+      message = helper.last_published_message('exchange1')
+      expect(message.data).to eq('last')
+    end
+
+    it 'returns the last message overall when no exchange specified' do
+      Ears::Testing.message_capture.add_message(
+        'exchange2',
+        'very_last',
+        'key3',
+      )
+      message = helper.last_published_message
+      expect(message.data).to eq('very_last')
+    end
+
+    it 'returns nil when no messages' do
+      helper.clear_published_messages
+      expect(helper.last_published_message).to be_nil
+    end
+  end
+
+  describe '#clear_published_messages' do
+    it 'clears all captured messages' do
+      helper.mock_ears('exchange1')
+      Ears::Testing.message_capture.add_message('exchange1', 'data', 'key')
+
+      helper.clear_published_messages
+
+      expect(helper.published_messages).to be_empty
+    end
+
+    it 'handles nil message_capture gracefully' do
+      expect { helper.clear_published_messages }.not_to raise_error
+    end
+  end
+
+  describe '#ears_reset!' do
+    let(:original_connection) { instance_double(Bunny::Session) }
+
+    before do
+      Ears.instance_variable_set(:@connection, original_connection)
+      helper.mock_ears('test_exchange')
+      Ears::Testing.message_capture.add_message('test', 'data', 'key')
+    end
+
+    it 'clears captured messages' do
+      helper.ears_reset!
+      expect(Ears::Testing.message_capture).to be_nil
+    end
+
+    it 'restores original connection' do
+      mock_connection = Ears.instance_variable_get(:@connection)
+      expect(mock_connection).not_to eq(original_connection)
+
+      helper.ears_reset!
+
+      expect(Ears.instance_variable_get(:@connection)).to eq(
+        original_connection,
+      )
+    end
+
+    it 'resets PublisherChannelPool if defined' do
+      helper.ears_reset!
+
+      expect(Ears::PublisherChannelPool.instance_variable_get(:@pool)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Provides RSpec helper method to test publisher behavior. Usage examples in https://github.com/ivx/time-off/pull/2856/files