### PR TITLE
Deal with closed channels when publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.22.2 (2025-01-19)
+
+### Fixed
+
+- Publisher now proactively detects and recovers from closed channels before attempting to publish, preventing `Bunny::ChannelAlreadyClosed` errors when channels are closed by RabbitMQ (e.g., due to missing queues or other channel-level errors)
+
 ## 0.22.1 (2025-09-11)
 
 - Add optional `routing_key_match` parameter to `#published_messages` in `Ears::Testing::TestHelper`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ears (0.22.1)
+    ears (0.22.2)
       bunny (>= 2.22.0)
       connection_pool (~> 2.4)
       multi_json
@@ -111,7 +111,7 @@ CHECKSUMS
   connection_pool (2.5.4) sha256=e9e1922327416091f3f6542f5f4446c2a20745276b9aa796dd0bb2fd0ea1e70a
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  ears (0.22.1)
+  ears (0.22.2)
   json (2.13.2) sha256=02e1f118d434c6b230a64ffa5c8dee07e3ec96244335c392eaed39e1199dbb68
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/lib/ears/version.rb
+++ b/lib/ears/version.rb
@@ -1,3 +1,3 @@
 module Ears
-  VERSION = '0.22.1'
+  VERSION = '0.22.2'
 end


### PR DESCRIPTION
We sometimes observe errors from Ears publishing on closed channel. We tackle this by validating the channel is open when publishing, and perform pool cleanup in case the channel is closed.